### PR TITLE
Beta Arm changes

### DIFF
--- a/src/main/java/frc/robot/OI.java
+++ b/src/main/java/frc/robot/OI.java
@@ -9,6 +9,7 @@ package frc.robot;
 
 import frc.robot.commands.*;
 import frc.robot.models.CustomXbox;
+import frc.robot.trigger.TurnOffAutoArm;
 
 /**
  * This class is the glue that binds the controls on the physical operator
@@ -19,6 +20,7 @@ public class OI {
   //Because the WPI bundled one is dumbbbbbbbbbbb
   public CustomXbox DriverStick = new CustomXbox(0);
   public CustomXbox AuxStick = new CustomXbox(1);
+  private TurnOffAutoArm turnOffAutoArm = new TurnOffAutoArm();
 
   //// TRIGGERING COMMANDS WITH BUTTONS
   // Once you have a button, it's trivial to bind it to a button in one of
@@ -65,6 +67,7 @@ public class OI {
     AuxStick.selectButton.whenPressed(new CC_ArmPstnPickupBall());
     AuxStick.startButton.whenPressed(new CC_ArmPstnPickupHatch());
 
+    turnOffAutoArm.whenActive(new CC_ArmAutoDisable());
   }
 
 }

--- a/src/main/java/frc/robot/OI.java
+++ b/src/main/java/frc/robot/OI.java
@@ -67,7 +67,7 @@ public class OI {
     AuxStick.selectButton.whenPressed(new CC_ArmPstnPickupBall());
     AuxStick.startButton.whenPressed(new CC_ArmPstnPickupHatch());
 
-    turnOffAutoArm.whenActive(new CC_ArmAutoDisable());
+    //turnOffAutoArm.whenActive(new CC_ArmAutoDisable());
   }
 
 }

--- a/src/main/java/frc/robot/calibrations/K_Arm.java
+++ b/src/main/java/frc/robot/calibrations/K_Arm.java
@@ -38,23 +38,24 @@ public class K_Arm {
 
     public final static PositionData[] ARM_POS_DATA = {
         new PositionData(0, "Floor Pickup", "Ball"),
-        new PositionData(24312, "Rocket Level 1", "Panel"),
-        new PositionData(114800, "Rocket Level 1", "Ball"),
-        new PositionData(173133, "Human Feed", "Ball"),
-        new PositionData(185000, "Rocket Level 2", "Panel"),
-        new PositionData(197000, "Cargo Ship", "Ball"),
-        new PositionData(254185, "Rocket Level 2", "Ball"),
-        new PositionData(312056, "Rocket Level 3", "Panel"),
-        new PositionData(402000, "Rocket Level 3", "Ball")
+        new PositionData(20500, "Rocket Level 1", "Panel"),
+        new PositionData(98000, "Rocket Level 1", "Ball"),
+        new PositionData(154500, "Rocket Level 2 / Cargo Ship", "Panel"),
+        new PositionData(229000, "Rocket Level 2", "Ball"),
+        new PositionData(297000, "Rocket Level 3", "Panel"),
+        new PositionData(388000, "Rocket Level 3", "Ball")
     };
     public final static int MAX_ARM_POSITION = ARM_POS_DATA.length - 1;
 
     // Define Ball Positions - Max is used to ensure no overflow errors
-    public final static int[] BALL_POSITIONS = {0, 2, 3, 5, 6, 8};
+    public final static int[] BALL_POSITIONS = {0, 2, 4, 6};
     public final static int MAX_BALL_POSITION = BALL_POSITIONS.length - 1;
 
     // Define Panel Positions - Max is used to ensure no overflow errors
-    public final static int[] PANEL_POSITIONS = {1, 4, 7};
+    public final static int[] PANEL_POSITIONS = {1, 3, 5};
     public final static int MAX_PANEL_POSITION = PANEL_POSITIONS.length - 1;
+
+    // This is the tolerance for all the arm position commands:
+    public final static int TOLERANCE = 1000;
     
 }

--- a/src/main/java/frc/robot/calibrations/K_Arm.java
+++ b/src/main/java/frc/robot/calibrations/K_Arm.java
@@ -6,64 +6,54 @@
 /*----------------------------------------------------------------------------*/
 
 package frc.robot.calibrations;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import frc.robot.models.PositionData;
 
 /**
  * Class: K_Arm - Contains Control Calibrations for the Arm system.
  */
 public class K_Arm {
 
-    /**************************************************************/
-	/*  Arm Position Encoder Counts Array Cell Index Assignments  */
-	/**************************************************************/	 	 
-    public static final int CeARM_BallPickUpFloor = 0;
-    public static final int CeARM_HatchLow        = 1;
-    public static final int CeARM_BallRocketLow   = 2;
-    public static final int CeARM_BallPickUpFeed  = 3;
-    public static final int CeARM_HatchMid        = 4;
-    public static final int CeARM_BallCargoShip   = 5;
-    public static final int CeARM_BallRocketMid   = 6;
-    public static final int CeARM_HatchHigh       = 7;
-    public static final int CeARM_BallRocketHigh  = 8;
-
-
     /********************************************/
 	/*  Arm Position Encoder Count Definitions  */
 	/********************************************/	 	
-	
-	/** KARM_Cnt_BallPickUpFloor: Arm Position in Encoder Counts associated
-     *  with the Floor for Ball/Cargo pick-up. */
-    public static final int KARM_Cnt_BallPickUpFloor = 0;  // Cell CeARM_BallPickUpFloor
+    // As a list, this is complicated to use but more precice (Using a set may be most precice)
+    // The idea is to use this as a stream and filter its use.
+    /*
+    public static List<PositionData> L_ARM_POS_DATA = Arrays.asList(
+        new PositionData(0, "Floor Pickup", "Ball"),
+        new PositionData(24312, "Rocket Level 1", "Panel"),
+        new PositionData(114800, "Rocket Level 1", "Ball"),
+        new PositionData(173133, "Human Feed", "Ball"),
+        new PositionData(185000, "Rocket Level 2", "Panel"),
+        new PositionData(197000, "Cargo Ship", "Ball"),
+        new PositionData(254185, "Rocket Level 2", "Ball"),
+        new PositionData(312056, "Rocket Level 3", "Panel"),
+        new PositionData(402000, "Rocket Level 3", "Ball")
+    );*/
 
- 	/** KARM_Cnt_BallPickUpFeed: Arm Position in Encoder Counts associated
-     *  with the Human Feed for Ball/Cargo pick-up. */
-     public static final int KARM_Cnt_BallPickUpFeed = 173133;  // Cell CeARM_BallPickUpFeed
+    public final static PositionData[] ARM_POS_DATA = {
+        new PositionData(0, "Floor Pickup", "Ball"),
+        new PositionData(24312, "Rocket Level 1", "Panel"),
+        new PositionData(114800, "Rocket Level 1", "Ball"),
+        new PositionData(173133, "Human Feed", "Ball"),
+        new PositionData(185000, "Rocket Level 2", "Panel"),
+        new PositionData(197000, "Cargo Ship", "Ball"),
+        new PositionData(254185, "Rocket Level 2", "Ball"),
+        new PositionData(312056, "Rocket Level 3", "Panel"),
+        new PositionData(402000, "Rocket Level 3", "Ball")
+    };
+    public final static int MAX_ARM_POSITION = ARM_POS_DATA.length - 1;
 
- 	/** KARM_Cnt_BallCargoShip: Arm Position in Encoder Counts associated
-     *  with the Cargo Ship Ball/Cargo placement. */
-     public static final int KARM_Cnt_BallCargoShip = 197000;  // Cell CeARM_BallCargoShip
+    // Define Ball Positions - Max is used to ensure no overflow errors
+    public final static int[] BALL_POSITIONS = {0, 2, 3, 5, 6, 8};
+    public final static int MAX_BALL_POSITION = BALL_POSITIONS.length - 1;
 
-	/** KARM_Cnt_BallRocketLow: Arm Position in Encoder Counts associated
-     *  with the Rocket LOW level Ball/Cargo placement. */
-    public static final int KARM_Cnt_BallRocketLow = 114800;  // Cell CeARM_BallRocketLow
-   
-	/** KARM_Cnt_BallRocketMid: Arm Position in Encoder Counts associated
-     *  with the Rocket MID level Ball/Cargo placement. */
-    public static final int KARM_Cnt_BallRocketMid =  254185;  // Cell CeARM_BallRocketMid
-    
-	/** KARM_Cnt_BallRocketHigh: Arm Position in Encoder Counts associated
-     *  with the Rocket HIGH level Ball/Cargo placement. */
-    public static final int KARM_Cnt_BallRocketHigh = 402000;  // Cell CeARM_BallRocketHigh
-
-	/** KARM_Cnt_HatchLow: Arm Position in Encoder Counts associated
-     *  with the LOW level hatch placement. */
-    public static final int KARM_Cnt_HatchLow = 24312;  // Cell CeARM_HatchLow
-
-	/** KARM_Cnt_HatchMid: Arm Position in Encoder Counts associated
-     *  with the MID level hatch placement. */
-    public static final int KARM_Cnt_HatchMid = 185000;  // Cell CeARM_HatchMid
-
-	/** KARM_Cnt_HatchHigh: Arm Position in Encoder Counts associated
-     *  with the HIGH level hatch placement. */
-    public static final int KARM_Cnt_HatchHigh = 312056;  // Cell CeARM_HatchHigh
+    // Define Panel Positions - Max is used to ensure no overflow errors
+    public final static int[] PANEL_POSITIONS = {1, 4, 7};
+    public final static int MAX_PANEL_POSITION = PANEL_POSITIONS.length - 1;
     
 }

--- a/src/main/java/frc/robot/calibrations/K_Arm.java
+++ b/src/main/java/frc/robot/calibrations/K_Arm.java
@@ -20,7 +20,7 @@ public class K_Arm {
     /********************************************/
 	/*  Arm Position Encoder Count Definitions  */
 	/********************************************/	 	
-    // As a list, this is complicated to use but more precice (Using a set may be most precice)
+    // As a list, this is complicated to use but most precice
     // The idea is to use this as a stream and filter its use.
     /*
     public static List<PositionData> L_ARM_POS_DATA = Arrays.asList(
@@ -33,7 +33,8 @@ public class K_Arm {
         new PositionData(254185, "Rocket Level 2", "Ball"),
         new PositionData(312056, "Rocket Level 3", "Panel"),
         new PositionData(402000, "Rocket Level 3", "Ball")
-    );*/
+    );
+    int[] test = L_ARM_POS_DATA.stream().filter(p -> p.name == "Ball" || p.name == "Both"). */
 
     public final static PositionData[] ARM_POS_DATA = {
         new PositionData(0, "Floor Pickup", "Ball"),

--- a/src/main/java/frc/robot/commands/CC_ArmAutoDisable.java
+++ b/src/main/java/frc/robot/commands/CC_ArmAutoDisable.java
@@ -9,17 +9,15 @@ package frc.robot.commands;
 
 import edu.wpi.first.wpilibj.command.InstantCommand;
 import frc.robot.Robot;
-import frc.robot.calibrations.K_Arm;
-import frc.robot.subsystems.Arm;
 
 /**
  * Add your docs here.
  */
-public class CC_ArmPstNextBall extends InstantCommand {
+public class CC_ArmAutoDisable extends InstantCommand {
   /**
    * Add your docs here.
    */
-  public CC_ArmPstNextBall() {
+  public CC_ArmAutoDisable() {
     super();
     // Use requires() here to declare subsystem dependencies
     // eg. requires(chassis);
@@ -29,12 +27,7 @@ public class CC_ArmPstNextBall extends InstantCommand {
   // Called once when the command executes
   @Override
   protected void initialize() {
-    if (K_Arm.MAX_BALL_POSITION != Robot.ARM.ballPoint){
-      Robot.ARM.ballPoint++;
-    }
-    Robot.ARM.AUTOMATIC_ACTIVE = true;
-    Robot.ARM.panelPoint = 0;
-    Robot.ARM.setSetPoint(Arm.getBalllevels(Robot.ARM.ballPoint));
+    Robot.ARM.AUTOMATIC_ACTIVE = false;
   }
 
 }

--- a/src/main/java/frc/robot/commands/CC_ArmPstNextBall.java
+++ b/src/main/java/frc/robot/commands/CC_ArmPstNextBall.java
@@ -1,0 +1,40 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.command.InstantCommand;
+import frc.robot.Robot;
+import frc.robot.calibrations.K_Arm;
+import frc.robot.subsystems.Arm;
+
+/**
+ * Add your docs here.
+ */
+public class CC_ArmPstNextBall extends InstantCommand {
+  /**
+   * Add your docs here.
+   */
+  public CC_ArmPstNextBall() {
+    super();
+    // Use requires() here to declare subsystem dependencies
+    // eg. requires(chassis);
+    requires(Robot.ARM);
+  }
+
+  // Called once when the command executes
+  @Override
+  protected void initialize() {
+    if (K_Arm.MAX_BALL_POSITION != Robot.ARM.ballPoint){
+      Robot.ARM.ballPoint++;
+    }
+    Robot.ARM.AUTOMATIC_ACTIVE = true;
+    Robot.ARM.panelPoint = 0;
+    Robot.ARM.setSetPoint(Arm.getBalllevels(Robot.ARM.ballPoint));
+  }
+
+}

--- a/src/main/java/frc/robot/commands/CC_ArmPstnPickupBall.java
+++ b/src/main/java/frc/robot/commands/CC_ArmPstnPickupBall.java
@@ -10,6 +10,7 @@ package frc.robot.commands;
 import edu.wpi.first.wpilibj.command.Command;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Robot;
+import frc.robot.calibrations.K_Arm;
 import frc.robot.subsystems.Arm;
 
 public class CC_ArmPstnPickupBall extends Command {
@@ -29,7 +30,7 @@ public class CC_ArmPstnPickupBall extends Command {
     Robot.ARM.setSetPoint(0);
     
     Robot.ARM.armSafety(false);
-    setLevel = Arm.ARMLEVELS[Robot.ARM.getSetPoint()];
+    setLevel = K_Arm.ARM_POS_DATA[Robot.ARM.getSetPoint()].location;
     Robot.ARM.MMArm(setLevel);
   }
 

--- a/src/main/java/frc/robot/commands/CC_ArmPstnPickupBall.java
+++ b/src/main/java/frc/robot/commands/CC_ArmPstnPickupBall.java
@@ -39,13 +39,14 @@ public class CC_ArmPstnPickupBall extends Command {
   protected void execute() {
     toSDBoard("Arm Data", Robot.ARM.liftRawPosition(), Robot.ARM.liftRawVelocity(), setLevel, Robot.ARM.armVoltage(),
         Robot.ARM.armError());
+        SmartDashboard.putString("Arm Level", K_Arm.ARM_POS_DATA[Robot.ARM.getSetPoint()].name);
 
   }
 
   // Make this return true when this Command no longer needs to run execute()
   @Override
   protected boolean isFinished() {
-    return Math.abs(Robot.ARM.liftRawPosition() - setLevel) < 1000;
+    return Math.abs(Robot.ARM.liftRawPosition() - setLevel) < K_Arm.TOLERANCE;
   }
 
   // Called once after isFinished returns true

--- a/src/main/java/frc/robot/commands/CC_ArmPstnPickupBall_2.java
+++ b/src/main/java/frc/robot/commands/CC_ArmPstnPickupBall_2.java
@@ -1,0 +1,38 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.command.InstantCommand;
+import frc.robot.Robot;
+import frc.robot.subsystems.Arm;
+
+/**
+ * Add your docs here.
+ */
+public class CC_ArmPstnPickupBall_2 extends InstantCommand {
+  /**
+   * Add your docs here.
+   */
+  public CC_ArmPstnPickupBall_2() {
+    super();
+    // Use requires() here to declare subsystem dependencies
+    // eg. requires(chassis);
+    requires(Robot.ARM);
+  }
+
+  // Called once when the command executes
+  @Override
+  protected void initialize() {
+    Robot.ARM.ballPoint = 0;
+
+    Robot.ARM.AUTOMATIC_ACTIVE = true;
+    Robot.ARM.panelPoint = 0;
+    Robot.ARM.setSetPoint(Arm.getBalllevels(Robot.ARM.ballPoint));
+  }
+
+}

--- a/src/main/java/frc/robot/commands/CC_ArmPstnPickupHatch.java
+++ b/src/main/java/frc/robot/commands/CC_ArmPstnPickupHatch.java
@@ -28,6 +28,8 @@ public class CC_ArmPstnPickupHatch extends Command {
   @Override
   protected void initialize() {
     Robot.ARM.setSetPoint(1);
+    Robot.ARM.ballPoint = 0;
+    Robot.ARM.panelPoint = 0;
     
     Robot.ARM.armSafety(false);
     setLevel = K_Arm.ARM_POS_DATA[Robot.ARM.getSetPoint()].location;
@@ -45,7 +47,7 @@ public class CC_ArmPstnPickupHatch extends Command {
   // Make this return true when this Command no longer needs to run execute()
   @Override
   protected boolean isFinished() {
-    return Math.abs(Robot.ARM.liftRawPosition() - setLevel) < 1000;
+    return Math.abs(Robot.ARM.liftRawPosition() - setLevel) < K_Arm.TOLERANCE;
   }
 
   // Called once after isFinished returns true

--- a/src/main/java/frc/robot/commands/CC_ArmPstnPickupHatch.java
+++ b/src/main/java/frc/robot/commands/CC_ArmPstnPickupHatch.java
@@ -10,6 +10,7 @@ package frc.robot.commands;
 import edu.wpi.first.wpilibj.command.Command;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Robot;
+import frc.robot.calibrations.K_Arm;
 import frc.robot.subsystems.Arm;
 
 public class CC_ArmPstnPickupHatch extends Command {
@@ -29,7 +30,7 @@ public class CC_ArmPstnPickupHatch extends Command {
     Robot.ARM.setSetPoint(1);
     
     Robot.ARM.armSafety(false);
-    setLevel = Arm.ARMLEVELS[Robot.ARM.getSetPoint()];
+    setLevel = K_Arm.ARM_POS_DATA[Robot.ARM.getSetPoint()].location;
     Robot.ARM.MMArm(setLevel);
   }
 

--- a/src/main/java/frc/robot/commands/CC_ArmPstnPickupHatch_2.java
+++ b/src/main/java/frc/robot/commands/CC_ArmPstnPickupHatch_2.java
@@ -1,0 +1,36 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.command.InstantCommand;
+import frc.robot.Robot;
+import frc.robot.subsystems.Arm;
+
+/**
+ * Add your docs here.
+ */
+public class CC_ArmPstnPickupHatch_2 extends InstantCommand {
+  /**
+   * Add your docs here.
+   */
+  public CC_ArmPstnPickupHatch_2() {
+    super();
+    requires(Robot.ARM);
+  }
+
+  // Called once when the command executes
+  @Override
+  protected void initialize() {
+    Robot.ARM.panelPoint = 0;
+
+    Robot.ARM.AUTOMATIC_ACTIVE = true;
+    Robot.ARM.ballPoint = 0;
+    Robot.ARM.setSetPoint(Arm.getPanellevels(Robot.ARM.panelPoint));
+  }
+
+}

--- a/src/main/java/frc/robot/commands/CC_ArmPstnRaise.java
+++ b/src/main/java/frc/robot/commands/CC_ArmPstnRaise.java
@@ -10,6 +10,7 @@ package frc.robot.commands;
 import edu.wpi.first.wpilibj.command.Command;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Robot;
+import frc.robot.calibrations.K_Arm;
 import frc.robot.subsystems.Arm;
 
 public class CC_ArmPstnRaise extends Command {
@@ -26,11 +27,11 @@ public class CC_ArmPstnRaise extends Command {
   // Called just before this Command runs the first time
   @Override
   protected void initialize() {
-    if (Robot.ARM.getSetPoint() < Arm.ARMLEVELS.length - 1){
+    if (Robot.ARM.getSetPoint() < K_Arm.MAX_ARM_POSITION - 1){
       Robot.ARM.setSetPoint(Robot.ARM.getSetPoint() + 1);
     }
     Robot.ARM.armSafety(false);
-    setLevel = Arm.ARMLEVELS[Robot.ARM.getSetPoint()];
+    setLevel = K_Arm.ARM_POS_DATA[Robot.ARM.getSetPoint()].location;
     Robot.ARM.MMArm(setLevel);
   }
 

--- a/src/main/java/frc/robot/commands/CC_ArmPstnRaiseNxtBallLvl.java
+++ b/src/main/java/frc/robot/commands/CC_ArmPstnRaiseNxtBallLvl.java
@@ -10,6 +10,7 @@ package frc.robot.commands;
 import edu.wpi.first.wpilibj.command.Command;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Robot;
+import frc.robot.calibrations.K_Arm;
 import frc.robot.subsystems.Arm;
 
 public class CC_ArmPstnRaiseNxtBallLvl extends Command {
@@ -23,12 +24,14 @@ public class CC_ArmPstnRaiseNxtBallLvl extends Command {
   // Called just before this Command runs the first time
   @Override
   protected void initialize() {
-    Robot.ARM.ballPoint++;
+    if (K_Arm.MAX_BALL_POSITION != Robot.ARM.ballPoint){
+      Robot.ARM.ballPoint++;
+    }
     Robot.ARM.panelPoint = 0;
     Robot.ARM.setSetPoint(Arm.getBalllevels(Robot.ARM.ballPoint));
     
     Robot.ARM.armSafety(false);
-    setLevel = Arm.ARMLEVELS[Robot.ARM.getSetPoint()];
+    setLevel = K_Arm.ARM_POS_DATA[Robot.ARM.getSetPoint()].location;
     Robot.ARM.MMArm(setLevel);
   }
 

--- a/src/main/java/frc/robot/commands/CC_ArmPstnRaiseNxtBallLvl.java
+++ b/src/main/java/frc/robot/commands/CC_ArmPstnRaiseNxtBallLvl.java
@@ -46,7 +46,7 @@ public class CC_ArmPstnRaiseNxtBallLvl extends Command {
   // Make this return true when this Command no longer needs to run execute()
   @Override
   protected boolean isFinished() {
-    return Math.abs(Robot.ARM.liftRawPosition() - setLevel) < 750;
+    return Math.abs(Robot.ARM.liftRawPosition() - setLevel) < K_Arm.TOLERANCE;
   }
 
   // Called once after isFinished returns true

--- a/src/main/java/frc/robot/commands/CC_ArmPstnRaiseNxtBallLvl_2.java
+++ b/src/main/java/frc/robot/commands/CC_ArmPstnRaiseNxtBallLvl_2.java
@@ -1,0 +1,40 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.command.InstantCommand;
+import frc.robot.Robot;
+import frc.robot.calibrations.K_Arm;
+import frc.robot.subsystems.Arm;
+
+/**
+ * Add your docs here.
+ */
+public class CC_ArmPstnRaiseNxtBallLvl_2 extends InstantCommand {
+  /**
+   * Add your docs here.
+   */
+  public CC_ArmPstnRaiseNxtBallLvl_2() {
+    super();
+    // Use requires() here to declare subsystem dependencies
+    // eg. requires(chassis);
+    requires(Robot.ARM);
+  }
+
+  // Called once when the command executes
+  @Override
+  protected void initialize() {
+    if (K_Arm.MAX_BALL_POSITION != Robot.ARM.ballPoint){
+      Robot.ARM.ballPoint++;
+    }
+    Robot.ARM.AUTOMATIC_ACTIVE = true;
+    Robot.ARM.panelPoint = 0;
+    Robot.ARM.setSetPoint(Arm.getBalllevels(Robot.ARM.ballPoint));
+  }
+
+}

--- a/src/main/java/frc/robot/commands/CC_ArmPstnRaiseNxtHatchLvl.java
+++ b/src/main/java/frc/robot/commands/CC_ArmPstnRaiseNxtHatchLvl.java
@@ -43,12 +43,13 @@ public class CC_ArmPstnRaiseNxtHatchLvl extends Command {
   protected void execute() {
     toSDBoard("Arm Data", Robot.ARM.liftRawPosition(), Robot.ARM.liftRawVelocity(), setLevel, Robot.ARM.armVoltage(),
       Robot.ARM.armError());
+      SmartDashboard.putString("Arm Level", K_Arm.ARM_POS_DATA[Robot.ARM.getSetPoint()].name);
   }
 
   // Make this return true when this Command no longer needs to run execute()
   @Override
   protected boolean isFinished() {
-    return Math.abs(Robot.ARM.liftRawPosition() - setLevel) < 750;
+    return Math.abs(Robot.ARM.liftRawPosition() - setLevel) < K_Arm.TOLERANCE;
   }
 
   // Called once after isFinished returns true

--- a/src/main/java/frc/robot/commands/CC_ArmPstnRaiseNxtHatchLvl.java
+++ b/src/main/java/frc/robot/commands/CC_ArmPstnRaiseNxtHatchLvl.java
@@ -10,6 +10,7 @@ package frc.robot.commands;
 import edu.wpi.first.wpilibj.command.Command;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Robot;
+import frc.robot.calibrations.K_Arm;
 import frc.robot.subsystems.Arm;
 
 public class CC_ArmPstnRaiseNxtHatchLvl extends Command {
@@ -26,12 +27,14 @@ public class CC_ArmPstnRaiseNxtHatchLvl extends Command {
   // Called just before this Command runs the first time
   @Override
   protected void initialize() {
-    Robot.ARM.panelPoint++;
+    if (K_Arm.MAX_PANEL_POSITION != Robot.ARM.panelPoint){
+      Robot.ARM.panelPoint++;
+    }
     Robot.ARM.ballPoint = 0;
     Robot.ARM.setSetPoint(Arm.getPanellevels(Robot.ARM.panelPoint));
     
     Robot.ARM.armSafety(false);
-    setLevel = Arm.ARMLEVELS[Robot.ARM.getSetPoint()];
+    setLevel = K_Arm.ARM_POS_DATA[Robot.ARM.getSetPoint()].location;
     Robot.ARM.MMArm(setLevel);
   }
 

--- a/src/main/java/frc/robot/commands/CC_ArmPstnRaiseNxtHatchLvl_2.java
+++ b/src/main/java/frc/robot/commands/CC_ArmPstnRaiseNxtHatchLvl_2.java
@@ -1,0 +1,38 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.command.InstantCommand;
+import frc.robot.Robot;
+import frc.robot.calibrations.K_Arm;
+import frc.robot.subsystems.Arm;
+
+/**
+ * Add your docs here.
+ */
+public class CC_ArmPstnRaiseNxtHatchLvl_2 extends InstantCommand {
+  /**
+   * Add your docs here.
+   */
+  public CC_ArmPstnRaiseNxtHatchLvl_2() {
+    super();
+    requires(Robot.ARM);
+  }
+
+  // Called once when the command executes
+  @Override
+  protected void initialize() {
+    if (K_Arm.MAX_PANEL_POSITION != Robot.ARM.panelPoint){
+      Robot.ARM.panelPoint++;
+    }
+    Robot.ARM.AUTOMATIC_ACTIVE = true;
+    Robot.ARM.ballPoint = 0;
+    Robot.ARM.setSetPoint(Arm.getPanellevels(Robot.ARM.panelPoint));
+  }
+
+}

--- a/src/main/java/frc/robot/commands/CC_ClawHatchCntrl.java
+++ b/src/main/java/frc/robot/commands/CC_ClawHatchCntrl.java
@@ -26,6 +26,7 @@ public class CC_ClawHatchCntrl extends Command {
   @Override
   protected void initialize() {
     Robot.CLAW.diskGrabber(out);
+    Robot.ARM.intakePower(out?-1.0:0);
   }
 
   // Called repeatedly when this Command is scheduled to run

--- a/src/main/java/frc/robot/commands/CT_ArmCntrl.java
+++ b/src/main/java/frc/robot/commands/CT_ArmCntrl.java
@@ -29,6 +29,7 @@ public class CT_ArmCntrl extends Command {
   protected void execute() {
     Robot.ARM.LiftByVoltage(Robot.m_oi.AuxStick.getLeftStickY());
     Robot.ARM.intakePower(Robot.m_oi.AuxStick.getRightStickY());
+    SmartDashboard.putNumber("ArmLevel", Robot.ARM.liftRawPosition());
     toSDBoard("Arm Data", Robot.ARM.liftRawPosition(), Robot.ARM.liftRawVelocity(), Robot.ARM.armVoltage());
   }
 

--- a/src/main/java/frc/robot/commands/CT_ArmCntrl_2.java
+++ b/src/main/java/frc/robot/commands/CT_ArmCntrl_2.java
@@ -8,62 +8,52 @@
 package frc.robot.commands;
 
 import edu.wpi.first.wpilibj.command.Command;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.Robot;
 import frc.robot.calibrations.K_Arm;
-import frc.robot.subsystems.Arm;
 
-public class CC_ArmPstnLower extends Command {
 
-  int setLevel = 0;
+/*********************************
+ * THIS CODE IS TO BE IMPLEMENTED WHEN EVERYONE IS GOOD WITH IT
+ */
 
-  public CC_ArmPstnLower() {
+public class CT_ArmCntrl_2 extends Command {
+  public CT_ArmCntrl_2() {
     // Use requires() here to declare subsystem dependencies
     // eg. requires(chassis);
     requires(Robot.ARM);
-
   }
 
   // Called just before this Command runs the first time
   @Override
   protected void initialize() {
-    if (Robot.ARM.getSetPoint() != 0){
-      Robot.ARM.setSetPoint(Robot.ARM.getSetPoint() - 1);
+    if (Robot.ARM.AUTOMATIC_ACTIVE){
+      Robot.ARM.MMArm(K_Arm.ARM_POS_DATA[Robot.ARM.getSetPoint()].location);
     }
-    
-    Robot.ARM.armSafety(false);
-    setLevel = K_Arm.ARM_POS_DATA[Robot.ARM.getSetPoint()].location;
-    Robot.ARM.MMArm(setLevel);
+    Robot.ARM.armSafety(!Robot.ARM.AUTOMATIC_ACTIVE);
   }
 
   // Called repeatedly when this Command is scheduled to run
   @Override
   protected void execute() {
-    toSDBoard("Arm Data", Robot.ARM.liftRawPosition(), Robot.ARM.liftRawVelocity(), setLevel, Robot.ARM.armVoltage(),
-        Robot.ARM.armError());
-
+    if (!Robot.ARM.AUTOMATIC_ACTIVE){
+      Robot.ARM.LiftByVoltage(Robot.m_oi.AuxStick.getLeftStickY());
+    }
   }
 
   // Make this return true when this Command no longer needs to run execute()
   @Override
   protected boolean isFinished() {
-    return Math.abs(Robot.ARM.liftRawPosition() - setLevel) < 1000;
+    return false;
   }
 
   // Called once after isFinished returns true
   @Override
   protected void end() {
-    Robot.ARM.armSafety(true);
   }
 
   // Called when another command which requires one or more of the same
   // subsystems is scheduled to run
   @Override
   protected void interrupted() {
-    end();
-  }
-
-  public void toSDBoard(String Name, double... toSDB) {
-    SmartDashboard.putNumberArray(Name, toSDB);
   }
 }

--- a/src/main/java/frc/robot/models/PositionData.java
+++ b/src/main/java/frc/robot/models/PositionData.java
@@ -1,0 +1,14 @@
+package frc.robot.models;
+
+// Define how the rocket data is to be stored, may eventually create get methods for access
+public class PositionData {
+    public int location;
+    public String name;
+    public String type; // Likely to be replaced by an enumeration
+
+    public PositionData (int location, String name, String type){
+        this.location = location;
+        this.name = name;
+        this.type = type;
+    }
+}

--- a/src/main/java/frc/robot/subsystems/Arm.java
+++ b/src/main/java/frc/robot/subsystems/Arm.java
@@ -25,20 +25,14 @@ public class Arm extends Subsystem {
 
   WPI_TalonSRX Lift = new WPI_TalonSRX(RobotMap.LiftMotorAddress);
   WPI_TalonSRX BallIntake = new WPI_TalonSRX(RobotMap.BallIntakeAddress);
-  final static public int[] ARMLEVELS = {K_Arm.KARM_Cnt_BallPickUpFloor,
-                                         K_Arm.KARM_Cnt_HatchLow,
-                                         K_Arm.KARM_Cnt_BallRocketLow,
-                                         K_Arm.KARM_Cnt_BallPickUpFeed,
-                                         K_Arm.KARM_Cnt_HatchMid,
-                                         K_Arm.KARM_Cnt_BallCargoShip,
-                                         K_Arm.KARM_Cnt_BallRocketMid,
-                                         K_Arm.KARM_Cnt_HatchHigh,
-                                         K_Arm.KARM_Cnt_BallRocketHigh};
-  final static private int[] BALLLEVELS = {0, 2, 3, 5, 6, ARMLEVELS.length-1};
-  final static private int[] PANELLEVELS = {1, 4, 7};
+  /************************************************
+   * Section depreciated of ARMLEVELS, use K_Arm.ARM_POS_LEVEL to replace this variable
+   * Reason for this is to provide a better model for how 
+  */
   private int setPoint = 0;
   public int ballPoint = 0;
   public int panelPoint = 0;
+  public boolean AUTOMATIC_ACTIVE = false;
   
 
   public Arm() {
@@ -49,7 +43,7 @@ public class Arm extends Subsystem {
     Lift.config_kP(0, 0.13);
     Lift.config_kI(0, 0.0001);
     Lift.config_kD(0, 0.0);
-    Lift.configForwardSoftLimitThreshold(ARMLEVELS[ARMLEVELS.length-1]);
+    Lift.configForwardSoftLimitThreshold(K_Arm.ARM_POS_DATA[K_Arm.MAX_ARM_POSITION].location); //ARMLEVELS[ARMLEVELS.length-1]);
     Lift.configForwardSoftLimitEnable(true);
   }
 
@@ -57,14 +51,14 @@ public class Arm extends Subsystem {
    * @return the balllevels
    */
   public static int getBalllevels(int level) {
-    return BALLLEVELS[level];
+    return K_Arm.BALL_POSITIONS[level];
   }
 
   /**
    * @return the panellevels
    */
   public static int getPanellevels(int level) {
-    return PANELLEVELS[level];
+    return K_Arm.PANEL_POSITIONS[level];
   }
 
   /**

--- a/src/main/java/frc/robot/trigger/TurnOffAutoArm.java
+++ b/src/main/java/frc/robot/trigger/TurnOffAutoArm.java
@@ -1,0 +1,21 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.trigger;
+
+import edu.wpi.first.wpilibj.buttons.Trigger;
+import frc.robot.Robot;
+
+/**
+ * Add your docs here.
+ */
+public class TurnOffAutoArm extends Trigger {
+  @Override
+  public boolean get() {
+    return Math.abs(Robot.m_oi.AuxStick.getLeftStickY()) > 0.3 && Robot.ARM.AUTOMATIC_ACTIVE ;
+  }
+}


### PR DESCRIPTION
Adds ability for next gen Arm Control, this is named with a 2 at the end of each command affected. What will happen is that the base teleop command will handle both joystick and motion magic controls. To do this I am setting a flag in the Arm subsystem to store which is to be used. I also am setting this flag to true whenever a command uses motion magic. The commands that set motion magic levels are now instant commands that just change the state of setPoints. To turn off automatic motion, a trigger has been made that when the joystick is move 0.2 in either direction the flag will be set to off. This will cause a new initialization of the command to turn it off and allow the command to allow voltage control

Also changed how Arm constants are stored and called. Created a data point model that stated data point, name of data point, data point type. I then leveraged this into the calibrations, and have depreciated all other uses of the data points. Please see K_Arm for details. This will eventually be used to display more information to the Dashboard.